### PR TITLE
Refactor: change xorg-server-utils to xorg-apps package

### DIFF
--- a/installation/030-install-xorg-ati.sh
+++ b/installation/030-install-xorg-ati.sh
@@ -15,7 +15,7 @@ echo "This is the opensource driver for nvidia"
 
 echo " Xserver setup"
 
-sudo pacman -S xorg-server xorg-server-utils xorg-xinit xorg-twm xterm --noconfirm --needed
+sudo pacman -S xorg-server xorg-apps xorg-xinit xorg-twm xterm --noconfirm --needed
 sudo pacman -S xf86-video-ati --noconfirm --needed
 
 echo "################################################################"

--- a/installation/030-install-xorg-intel.sh
+++ b/installation/030-install-xorg-intel.sh
@@ -15,7 +15,7 @@ echo "This is the opensource driver for nvidia"
 
 echo " Xserver setup"
 
-sudo pacman -S xorg-server xorg-server-utils xorg-xinit xorg-twm xterm --noconfirm --needed
+sudo pacman -S xorg-server xorg-apps xorg-xinit xorg-twm xterm --noconfirm --needed
 sudo pacman -S xf86-video-intel --noconfirm --needed
 
 echo "################################################################"

--- a/installation/030-install-xorg-nvidia.sh
+++ b/installation/030-install-xorg-nvidia.sh
@@ -15,7 +15,7 @@ echo "This is the opensource driver for nvidia"
 
 echo " Xserver setup"
 
-sudo pacman -S xorg-server xorg-server-utils xorg-xinit xorg-twm xterm --noconfirm --needed
+sudo pacman -S xorg-server xorg-apps xorg-xinit xorg-twm xterm --noconfirm --needed
 sudo pacman -S xf86-video-nouveau --noconfirm --needed
 
 echo "################################################################"

--- a/installation/030-install-xorg-virtualbox.sh
+++ b/installation/030-install-xorg-virtualbox.sh
@@ -13,7 +13,7 @@ set -e
 
 echo " Xserver setup"
 
-sudo pacman -S xorg-server xorg-server-utils xorg-xinit xorg-twm xterm --noconfirm --needed
+sudo pacman -S xorg-server xorg-apps xorg-xinit xorg-twm xterm --noconfirm --needed
 echo
 echo "################################################################"
 echo "choose virtualbox-guest-modules-arch in the next installation"


### PR DESCRIPTION
It seems that xorg-server-utils no longer exists, and now the xorg utilities are grouped in the xorg-apps package

See: https://wiki.archlinux.org/index.php/xorg#Installation